### PR TITLE
Fix preact JSON VNode Injection vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5110,9 +5110,9 @@
       "license": "MIT"
     },
     "node_modules/preact": {
-      "version": "10.26.5",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.26.5.tgz",
-      "integrity": "sha512-fmpDkgfGU6JYux9teDWLhj9mKN55tyepwYbxHgQuIxbWQzgFg5vk7Mrrtfx7xRxq798ynkY4DDDxZr235Kk+4w==",
+      "version": "10.28.2",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.28.2.tgz",
+      "integrity": "sha512-lbteaWGzGHdlIuiJ0l2Jq454m6kcpI1zNje6d8MlGAFlYvP2GO4ibnat7P74Esfz4sPTdM6UxtTwh/d3pwM9JA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",


### PR DESCRIPTION
## Summary
- Updates preact from 10.26.5 to 10.28.2
- Fixes high severity JSON VNode Injection vulnerability (GHSA-36hm-qxxp-pg3m)

## Test plan
- [x] Verified via `npm audit` that preact vulnerability is resolved
- [ ] Verify build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)